### PR TITLE
Bugfix: Location rolls failing with a pass but no raises.

### DIFF
--- a/module/lib/utils.js
+++ b/module/lib/utils.js
@@ -1710,6 +1710,9 @@ const dc_utils = {
                 let tot = loc_roll._total - 1;
                 let found = [];
                 let range = raises * 2 || 0;
+                if (range == 0) {
+                    return dc_utils.loc_lookup[tot];
+                }
                 for (let i = tot - range; i < tot + range; i++) {
                     console.log(i, dc_utils.loc_lookup[i]);
                     if (dc_utils.loc_lookup[i] != undefined) {

--- a/system.json
+++ b/system.json
@@ -2,7 +2,7 @@
     "name": "deadlands_classic",
     "title": "Deadlands Classic",
     "description": "An implementation of a classic wild west roleplay system.",
-    "version": "0.3.3",
+    "version": "0.3.4",
     "minimumCoreVersion": "0.8.0",
     "compatibleCoreVersion": "0.8.8",
     "templateVersion": 1,
@@ -25,6 +25,6 @@
     "secondaryTokenAttribute": "rounds",
     "url": "https://github.com/RhombusWeasel/Deadlands-Classic",
     "manifest": "https://raw.githubusercontent.com/RhombusWeasel/Deadlands-Classic/main/system.json",
-    "download": "https://github.com/RhombusWeasel/Deadlands-Classic/releases/download/0.3.3/deadlands_classic.zip",
+    "download": "https://github.com/RhombusWeasel/Deadlands-Classic/releases/download/0.3.4/deadlands_classic.zip",
     "license": "LICENSE.txt"
   }


### PR DESCRIPTION
dc_utils.roll.location_roll now returns the lookup for the value rolled in the case of no raises to calculate.